### PR TITLE
Change the definition of PID parameters in sdf

### DIFF
--- a/include/rover_gazebo_plugins/rover_gazebo_joint_plugin.hpp
+++ b/include/rover_gazebo_plugins/rover_gazebo_joint_plugin.hpp
@@ -6,6 +6,41 @@
 namespace gazebo_plugins
 {
 class RoverGazeboJointPluginPrivate;
+/// Set the PID parameters of joints
+///
+/// The plugin iterates over all joints
+/// and sets the PID if the joint name contains the PID identifier.
+/// The order of the parameters matter, if you define first the PID parameters 
+/// for a group of joints and afterwards for a specific joint of that group,
+/// the first value is overwritten with the second one.
+/**
+    Example usage:
+    \code{.xml}
+      <plugin name="rover_gazebo_joint_plugin" 
+            filename="librover_gazebo_joint_plugin.so">
+
+        <!-- Add a namespace -->
+        <ros>
+           <namespace>/my_namespace</namespace>
+        </ros>
+
+        <!-- Update rate in Hz -->
+        <update_rate>100.0</update_rate>
+        
+        <!-- Parameters for position PIDs -->
+        <position_pids>
+          <DEP>350.0 0.1 0.0</DEP>
+          <STR>20.0 0.1 0.0</STR>
+        </position_pids>
+
+        <!-- Parameters for velocity PIDs -->
+        <velocity_pids>
+          <DRV>5.0 0.1 0.0</DRV>
+        </velocity_pids>
+      </plugin
+  \endcode
+  
+*/
 
 class RoverGazeboJointPlugin : public gazebo::ModelPlugin
 {

--- a/src/rover_gazebo_joint_plugin.cpp
+++ b/src/rover_gazebo_joint_plugin.cpp
@@ -122,17 +122,17 @@ namespace gazebo_plugins
         impl_->LoadPIDParametersFromSDF(_sdf);
 
         // Set the PIDs of the joints accordingly to the given parameters
-        for (auto const &pair : impl_->position_pid_parameters)
+        for (auto const &position_pid_parameter_element : impl_->position_pid_parameters)
         {
-            auto pid_identifier = pair.first;
-            auto parameters = pair.second;
+            auto pid_identifier = position_pid_parameter_element.first;
+            auto parameters = position_pid_parameter_element.second;
 
             RCLCPP_DEBUG(impl_->ros_node_->get_logger(), "Position PID parameter: %s, Values: %f %f %f", pid_identifier.c_str(), parameters.X(), parameters.Y(), parameters.Z());
 
-            for (auto const &pair : impl_->joint_controller_->GetJoints())
+            for (auto const &joint_element : impl_->joint_controller_->GetJoints())
             {
-                auto joint_name = pair.first;
-                auto joint = pair.second;
+                auto joint_name = joint_element.first;
+                auto joint = joint_element.second;
 
                 if (joint_name.find(pid_identifier.c_str()) != std::string::npos)
                 {
@@ -143,17 +143,17 @@ namespace gazebo_plugins
             }
         }
 
-        for (auto const &pair : impl_->velocity_pid_parameters)
+        for (auto const &velocity_pid_parameter_element : impl_->velocity_pid_parameters)
         {
-            auto pid_identifier = pair.first;
-            auto parameters = pair.second;
+            auto pid_identifier = velocity_pid_parameter_element.first;
+            auto parameters = velocity_pid_parameter_element.second;
 
             RCLCPP_DEBUG(impl_->ros_node_->get_logger(), "Velocity PID parameter: %s, Values: %f %f %f", pid_identifier.c_str(), parameters.X(), parameters.Y(), parameters.Z());
 
-            for (auto const &pair : impl_->joint_controller_->GetJoints())
+            for (auto const &joint_element : impl_->joint_controller_->GetJoints())
             {
-                auto joint_name = pair.first;
-                auto joint = pair.second;
+                auto joint_name = joint_element.first;
+                auto joint = joint_element.second;
 
                 if (joint_name.find(pid_identifier.c_str()) != std::string::npos)
                 {
@@ -218,7 +218,7 @@ namespace gazebo_plugins
             {
                 if (!joint_controller_->SetPositionTarget(model_->GetJoint(cmd.name)->GetScopedName(), cmd.value))
                 {
-                    RCLCPP_WARN(ros_node_->get_logger(), "Joint %s from recieved command was npt found in model.", cmd.name.c_str());
+                    RCLCPP_WARN(ros_node_->get_logger(), "Joint %s from received command was not found in model.", cmd.name.c_str());
                 }
             }
             else if (cmd.mode == "VELOCITY")

--- a/src/rover_gazebo_joint_plugin.cpp
+++ b/src/rover_gazebo_joint_plugin.cpp
@@ -126,6 +126,7 @@ namespace gazebo_plugins
         {
             auto pid_identifier = position_pid_parameter_element.first;
             auto parameters = position_pid_parameter_element.second;
+            bool parameter_has_joint = false;
 
             RCLCPP_DEBUG(impl_->ros_node_->get_logger(), "Position PID parameter: %s, Values: %f %f %f", pid_identifier.c_str(), parameters.X(), parameters.Y(), parameters.Z());
 
@@ -136,10 +137,16 @@ namespace gazebo_plugins
 
                 if (joint_name.find(pid_identifier.c_str()) != std::string::npos)
                 {
+                    parameter_has_joint = true;
                     impl_->joint_controller_->SetPositionPID(joint_name, gazebo::common::PID(parameters.X(), parameters.Y(), parameters.Z()));
                     impl_->joint_controller_->SetPositionTarget(joint_name, 0.0);
                     RCLCPP_DEBUG(impl_->ros_node_->get_logger(), "Set position PID on joint: %s to P: %f I: %f D: %f", joint_name.c_str(), parameters.X(), parameters.Y(), parameters.Z());
                 }
+            }
+
+            if(!parameter_has_joint)
+            {
+                RCLCPP_WARN(impl_->ros_node_->get_logger(), "No joint found for Parameter %s. Maybe there is a type or your config is not up to date.", pid_identifier.c_str());
             }
         }
 
@@ -147,6 +154,7 @@ namespace gazebo_plugins
         {
             auto pid_identifier = velocity_pid_parameter_element.first;
             auto parameters = velocity_pid_parameter_element.second;
+            bool parameter_has_joint = false;
 
             RCLCPP_DEBUG(impl_->ros_node_->get_logger(), "Velocity PID parameter: %s, Values: %f %f %f", pid_identifier.c_str(), parameters.X(), parameters.Y(), parameters.Z());
 
@@ -157,10 +165,15 @@ namespace gazebo_plugins
 
                 if (joint_name.find(pid_identifier.c_str()) != std::string::npos)
                 {
+                    parameter_has_joint = true;
                     impl_->joint_controller_->SetVelocityPID(joint_name, gazebo::common::PID(parameters.X(), parameters.Y(), parameters.Z()));
                     impl_->joint_controller_->SetVelocityTarget(joint_name, 0.0);
                     RCLCPP_DEBUG(impl_->ros_node_->get_logger(), "Set velocity PID on joint: %s to P: %f I: %f D: %f", joint_name.c_str(), parameters.X(), parameters.Y(), parameters.Z());
                 }
+            }
+            if(!parameter_has_joint)
+            {
+                RCLCPP_WARN(impl_->ros_node_->get_logger(), "No joint found for Parameter %s. Maybe there is a type or your config is not up to date.", pid_identifier.c_str());
             }
         }
 


### PR DESCRIPTION
Position and velocity PIDs can now be created for all joints, or groups of joints.

For an example of sdf definition, also pull the newest version of rover_config.